### PR TITLE
Fix the deployment template so as to accept null in replicacount

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -30,7 +30,7 @@ metadata:
 {{ toYaml .Values.controller.extraLabels | indent 4 }}
     {{- end }}
 spec:
-  {{- if not .Values.controller.autoscaling.enabled }}
+  {{- if not ( kindIs "invalid" .Values.controller.replicaCount) }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   selector:

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  {{- if not .Values.defaultBackend.autoscaling.enabled }}
+  {{- if not (kindIs "invalid" .Values.defaultBackend.replicaCount) }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   {{- end }}
   selector:


### PR DESCRIPTION
I forked the original haproxy repo with tag `kubernetes-ingress-1.12.0` into our netdata/haproxy `master` and then i did the changes we need in another repo and create the PR